### PR TITLE
Export router error fields to be usable in external middleware

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -50,7 +50,7 @@ func Logger(out io.Writer) func(*Context) error {
 
 		white.Fprintf(out, "\n%"+indent+"v └── ", "")
 		if err != nil {
-			if e, ok := err.(*Error); ok && e.code == 404 {
+			if e, ok := err.(*Error); ok && e.Code == 404 {
 				yellow.Fprint(out, err)
 			} else {
 				red.Fprint(out, err)

--- a/router.go
+++ b/router.go
@@ -29,15 +29,15 @@ type Router struct {
 }
 
 type Error struct {
-	message string
-	code    uint16
+	Message string
+	Code    uint16
 }
 
 func (e Error) Error() string {
-	if e.code != 0 {
-		return fmt.Sprintf("%d: %s", e.code, e.message)
+	if e.Code != 0 {
+		return fmt.Sprintf("%d: %s", e.Code, e.Message)
 	}
-	return e.message
+	return e.Message
 }
 
 // New returns a router.
@@ -258,8 +258,8 @@ func (r *Router) routeMiddleware(c *Context) error {
 	}
 
 	return &Error{
-		message: fmt.Sprintf("missed handler for '%s'", c.Path),
-		code:    404,
+		Message: fmt.Sprintf("missed handler for '%s'", c.Path),
+		Code:    404,
 	}
 }
 


### PR DESCRIPTION
It's quite useful for custom logger:

```go
s.r.Use(func(c *tgbot.Context) error {
	start := time.Now()
	p := c.Path
	err := c.Next()
	pp := c.Path

	logger := s.Logger.WithFields(logrus.Fields{
		"user_id": c.From.ID,
		"chat_id": c.Chat.ID,
		"path":    p,
		"timeout": time.Now().Sub(start),
	})

	if c.Text != "" {
		logger = logger.WithField("payload", c.Text)
	}

	if p != pp {
		logger = logger.WithField("override", pp)
	}

	if err != nil {
		e, ok := err.(*tgbot.Error)

		if !ok {
			logger.Errorln(err)
			return err
		}

		switch e.Code {
		case 404:
			if s.Debug {
				logger.Errorln(e.Message)
			}
		default:
			logger.Errorln(e.Message)
		}

		return e
	}

	logger.Infoln("OK")
	return nil
})
```